### PR TITLE
Removed InvalidArgument from scale

### DIFF
--- a/src/scale.js
+++ b/src/scale.js
@@ -6,7 +6,6 @@
   }
 
   function scaleParse (input) {
-    var InvalidArgument = internalScope.InvalidArgument;
     /* According to spec:
       https://drafts.csswg.org/css-transforms-2/#propdef-scale
       unspecified scales default to 1
@@ -20,12 +19,12 @@
     var values = input.split(/\s+/);
     var numValues = values.length;
     if (numValues < 1 || numValues > 3) {
-      throw new InvalidArgument('Incorrect number of values for scale');
+      return undefined;       // Incorrect number of values for scale
     }
 
     for (var i = 0; i < numValues; i++) {
       if (values[i] === '' || !isNumeric(values[i])) {
-        throw new InvalidArgument('Argument must be a number');
+        return undefined;     // Argument must be a number
       }
     }
 
@@ -48,23 +47,11 @@
     };
   }
 
-  function parseManager (input) {
-    var InvalidArgument = internalScope.InvalidArgument;
-    try {
-      return scaleParse(input);
-    } catch (error) {
-      if (error.constructor === InvalidArgument) {
-        return undefined;
-      }
-      throw error;
-    }
-  }
-
   WebAnimationsPolyfillExtension.register({
     name: 'scale',
     properties: {
       scale: {
-        parse: parseManager,
+        parse: scaleParse,
         merge: merge
       }
     },
@@ -73,7 +60,7 @@
         var transformString = internalScope.toTransform(values);
         return {transform: transformString + ' ' + values.transform};
       },
-      watchedProperties: ['scale', 'transform']
+      watchedProperties: ['scale', 'rotate', 'transform']
     }
   });
   internalScope.scaleParse = scaleParse;

--- a/src/scale.js
+++ b/src/scale.js
@@ -19,12 +19,14 @@
     var values = input.split(/\s+/);
     var numValues = values.length;
     if (numValues < 1 || numValues > 3) {
-      return undefined;       // Incorrect number of values for scale
+      // Incorrect number of values for scale
+      return undefined;
     }
 
     for (var i = 0; i < numValues; i++) {
       if (values[i] === '' || !isNumeric(values[i])) {
-        return undefined;     // Argument must be a number
+        // Argument must be a number
+        return undefined;
       }
     }
 
@@ -60,7 +62,7 @@
         var transformString = internalScope.toTransform(values);
         return {transform: transformString + ' ' + values.transform};
       },
-      watchedProperties: ['scale', 'rotate', 'transform']
+      watchedProperties: ['scale', 'transform']
     }
   });
   internalScope.scaleParse = scaleParse;

--- a/test/scaleTest.js
+++ b/test/scaleTest.js
@@ -1,4 +1,4 @@
-/* global suite test assert internalScope */
+/* global suite test assert */
 
 function checkTransformKeyframes (keyframes) {
   var target = document.createElement('div');
@@ -35,26 +35,16 @@ function isAnimationEqual (actualKeyframes, expectedKeyframes) {
     actualTarget.remove();
     expectedTarget.remove();
 
-    assert.equal(result, expected, 'at currentTime ' + currentTime + ' comparing ' + actualKeyframes + ' with ' + expectedKeyframes);
+    assert.equal(result, expected, 'at currentTime ' + currentTime + ' comparing ' + JSON.stringify(actualKeyframes) + ' with ' + JSON.stringify(expectedKeyframes));
   }
 }
 
 suite('transforms', function () {
   test('scaleTransform', function () {
-    var InvalidArgument = internalScope.InvalidArgument;
-
     isAnimationEqual({scale: ['0.5', '2.5']}, {transform: ['scale3d(0.5, 1, 1)', 'scale3d(2.5, 1, 1)']});
     isAnimationEqual({scale: ['9 2', '2 2']}, {transform: ['scale3d(9, 2, 1)', 'scale3d(2, 2, 1)']});
     isAnimationEqual({scale: ['1 2 3', '3 4 5']}, {transform: ['scale3d(1, 2, 3)', 'scale3d(3, 4, 5)']});
     isAnimationEqual({scale: ['none', '8']}, {transform: ['scale3d(1, 1, 1)', 'scale3d(8, 1, 1)']});
     isAnimationEqual({scale: ['2', '3 4']}, {transform: ['scale3d(2, 1, 1)', 'scale3d(3, 4, 1)']});
-
-    assert.throws(function () {
-      isAnimationEqual({scale: ['0.5 garbage', '2.5']}, {transform: ['none', 'scale3d(2.5, 1, 1)']});
-    }, InvalidArgument);
-
-    assert.throws(function () {
-      isAnimationEqual({scale: ['1 2 3 4', '2.5']}, {transform: ['none', 'scale3d(2.5, 1, 1)']});
-    }, InvalidArgument);
   });
 });

--- a/test/scaleTest.js
+++ b/test/scaleTest.js
@@ -1,50 +1,59 @@
 /* global suite test assert */
 
-function checkTransformKeyframes (keyframes) {
-  var target = document.createElement('div');
+(function () {
+  var InvalidTransformValue = {};
 
-  for (var value of keyframes) {
-    target.style.transform = '';
-    target.style.transform = value;
-    assert.notEqual(target.style.transform, '',
-      'Invalid expected keyframe: ' + value);
+  function checkTransformKeyframes (keyframes) {
+    var target = document.createElement('div');
+
+    for (var value of keyframes) {
+      target.style.transform = '';
+      target.style.transform = value;
+      if (value === InvalidTransformValue) {
+        continue;
+      }
+
+      assert.notEqual(target.style.transform, '',
+        'Invalid expected keyframe: ' + value);
+    }
   }
-}
 
-function isAnimationEqual (actualKeyframes, expectedKeyframes) {
-  var timing = {duration: 1};
-  var currentTimes = [0.10, 0.25, 0.50, 0.75, 0.90];
+  function isAnimationEqual (actualKeyframes, expectedKeyframes) {
+    var timing = {duration: 1};
+    var currentTimes = [0.10, 0.25, 0.50, 0.75, 0.90];
 
-  checkTransformKeyframes(expectedKeyframes.transform);
+    checkTransformKeyframes(expectedKeyframes.transform);
 
-  for (var currentTime of currentTimes) {
-    var actualTarget = document.createElement('div');
-    document.body.appendChild(actualTarget);
+    for (var currentTime of currentTimes) {
+      var actualTarget = document.createElement('div');
+      document.body.appendChild(actualTarget);
 
-    var expectedTarget = document.createElement('div');
-    document.body.appendChild(expectedTarget);
+      var expectedTarget = document.createElement('div');
+      document.body.appendChild(expectedTarget);
 
-    var animation = actualTarget.animate(actualKeyframes, timing);
-    animation.currentTime = currentTime;
-    var result = window.getComputedStyle(actualTarget).transform;
+      var animation = actualTarget.animate(actualKeyframes, timing);
+      animation.currentTime = currentTime;
+      var result = window.getComputedStyle(actualTarget).transform;
 
-    animation = expectedTarget.animate(expectedKeyframes, timing);
-    animation.currentTime = currentTime;
-    var expected = window.getComputedStyle(expectedTarget).transform;
+      animation = expectedTarget.animate(expectedKeyframes, timing);
+      animation.currentTime = currentTime;
+      var expected = window.getComputedStyle(expectedTarget).transform;
 
-    actualTarget.remove();
-    expectedTarget.remove();
+      actualTarget.remove();
+      expectedTarget.remove();
 
-    assert.equal(result, expected, 'at currentTime ' + currentTime + ' comparing ' + JSON.stringify(actualKeyframes) + ' with ' + JSON.stringify(expectedKeyframes));
+      assert.equal(result, expected, 'at currentTime ' + currentTime + ' comparing ' + JSON.stringify(actualKeyframes) + ' with ' + JSON.stringify(expectedKeyframes));
+    }
   }
-}
 
-suite('transforms', function () {
-  test('scaleTransform', function () {
-    isAnimationEqual({scale: ['0.5', '2.5']}, {transform: ['scale3d(0.5, 1, 1)', 'scale3d(2.5, 1, 1)']});
-    isAnimationEqual({scale: ['9 2', '2 2']}, {transform: ['scale3d(9, 2, 1)', 'scale3d(2, 2, 1)']});
-    isAnimationEqual({scale: ['1 2 3', '3 4 5']}, {transform: ['scale3d(1, 2, 3)', 'scale3d(3, 4, 5)']});
-    isAnimationEqual({scale: ['none', '8']}, {transform: ['scale3d(1, 1, 1)', 'scale3d(8, 1, 1)']});
-    isAnimationEqual({scale: ['2', '3 4']}, {transform: ['scale3d(2, 1, 1)', 'scale3d(3, 4, 1)']});
+  suite('transforms', function () {
+    test('scaleTransform', function () {
+      isAnimationEqual({scale: ['0.5', '2.5']}, {transform: ['scale3d(0.5, 1, 1)', 'scale3d(2.5, 1, 1)']});
+      isAnimationEqual({scale: ['9 2', '2 2']}, {transform: ['scale3d(9, 2, 1)', 'scale3d(2, 2, 1)']});
+      isAnimationEqual({scale: ['1 2 3', '3 4 5']}, {transform: ['scale3d(1, 2, 3)', 'scale3d(3, 4, 5)']});
+      isAnimationEqual({scale: ['none', '8']}, {transform: ['scale3d(1, 1, 1)', 'scale3d(8, 1, 1)']});
+      isAnimationEqual({scale: ['2', '3 4']}, {transform: ['scale3d(2, 1, 1)', 'scale3d(3, 4, 1)']});
+      isAnimationEqual({scale: ['1 2 3 4', '3 4']}, {transform: [InvalidTransformValue, 'scale3d(3, 4, 1)']});
+    });
   });
-});
+})();

--- a/test/scaleTest.js
+++ b/test/scaleTest.js
@@ -54,6 +54,7 @@
       isAnimationEqual({scale: ['none', '8']}, {transform: ['scale3d(1, 1, 1)', 'scale3d(8, 1, 1)']});
       isAnimationEqual({scale: ['2', '3 4']}, {transform: ['scale3d(2, 1, 1)', 'scale3d(3, 4, 1)']});
       isAnimationEqual({scale: ['1 2 3 4', '3 4']}, {transform: [InvalidTransformValue, 'scale3d(3, 4, 1)']});
+      isAnimationEqual({scale: ['0.5 garbage', '2.5']}, {transform: [InvalidTransformValue, 'scale3d(2.5, 1, 1)']});
     });
   });
 })();

--- a/test/toTransform.js
+++ b/test/toTransform.js
@@ -65,7 +65,6 @@
     });
 
     test('convertScale', function () {
-
       assert.equal(toTransform({scale: ''}), 'none');
       assert.equal(toTransform({scale: 'a'}), 'none');
       assert.equal(toTransform({scale: '2 a'}), 'none');

--- a/test/toTransform.js
+++ b/test/toTransform.js
@@ -65,24 +65,13 @@
     });
 
     test('convertScale', function () {
-      assert.throws(function () {
-        toTransform({scale: ''});
-      }, InvalidArgument);
 
-      assert.throws(function () {
-        toTransform({scale: 'a'});
-      }, InvalidArgument);
-
-      assert.throws(function () {
-        toTransform({scale: '2 a'});
-      }, InvalidArgument);
-
-      assert.throws(function () {
-        toTransform({scale: '2 3 4 5'});
-      }, InvalidArgument);
+      assert.equal(toTransform({scale: ''}), 'none');
+      assert.equal(toTransform({scale: 'a'}), 'none');
+      assert.equal(toTransform({scale: '2 a'}), 'none');
+      assert.equal(toTransform({scale: '2 3 4 5'}), 'none');
 
       assert.equal(toTransform({scale: 'none'}), 'scale3d(1, 1, 1)');
-
       assert.equal(toTransform({scale: '2'}), 'scale3d(2, 1, 1)');
       assert.equal(toTransform({scale: '2 3'}), 'scale3d(2, 3, 1)');
       assert.equal(toTransform({scale: '2 3 4'}), 'scale3d(2, 3, 4)');


### PR DESCRIPTION
We no longer want to throw errors as the animations engine expects parse to return undefined on invalid input. As a result we no longer need the InvalidArgument function.

This also means that we had to alter tests that involved an InvalidArgument error being thrown. Instead there is now an 'InvalidTransformValue' object which we use in tests with invalid arguments. 