### PR TITLE
Support for the polygon basic shape in offsetPath. Only supports pixels.

### DIFF
--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -2,30 +2,32 @@
 'use strict';
 
 (function () {
-  function basicShapeInset(arguments) {
-    // WIP
-    return null;
-  }
-
-  function basicShapeCircle(arguments) {
-    var isNumeric = internalScope.isNumeric;
-    var argumentList = arguments.split(/\s+/);
-
-    var radius = argumentList[0];
-    // Negative radius is invalid
-    // Radius defaults to closest side 
-
-    return null;
-  }
-
-  function basicShapeEllipse(arguments) {
-    // WIP
-    return null;
-  }
-
-  function basicShapePolygon(arguments) {
-    // WIP
-    return null;
+  function basicShapePolygon (input) {
+    // TODO: Support the fill-rule option and %
+    var argumentList = input.split(',');
+    var coordinate = null;
+    var x = null;
+    var y = null;
+    var previousX = 0;
+    var previousY = 0;
+    var path = 'm 0 0';
+    // Do something here if not at least 3 vertices?
+    for (var i = 0; i < argumentList.length; i++) {
+      coordinate = argumentList[i].trim().split(/\s+/);
+      if (coordinate.length !== 2) {
+        return undefined;
+      }
+      x = internalScope.offsetDistanceParse(coordinate[0]);
+      y = internalScope.offsetDistanceParse(coordinate[1]);
+      if (!x || !y || x.unit === '%' || y.unit === '%') {
+        return undefined;
+      }
+      path += ' h ' + (x.value - previousX) + ' v ' + (y.value - previousY);
+      previousX = x.value;
+      previousY = y.value;
+    }
+    path += ' z';
+    return {type: 'path', path: path};
   }
 
   function offsetPathParse (input) {
@@ -85,12 +87,9 @@
       }
 
       var shapeArguments = /\(([^)]+)\)/.exec(input);
-      
-      if(shapeType[0] === 'circle') {
-        return basicShapeCircle(shapeArguments[1]);
+      if (shapeType[0] === 'polygon') {
+        return basicShapePolygon(shapeArguments[1]);
       }
-
-      // return {type: shapeType[0], path: shapeArguments[1]};
     }
   }
 

--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -22,7 +22,7 @@
       if (!x || !y || x.unit === '%' || y.unit === '%') {
         return undefined;
       }
-      path += ' h ' + (x.value - previousX) + ' v ' + (y.value - previousY);
+      path += ' l ' + (x.value - previousX) + ' ' + (y.value - previousY);
       previousX = x.value;
       previousY = y.value;
     }

--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -10,7 +10,7 @@
     var y = null;
     var previousX = 0;
     var previousY = 0;
-    var path = 'm 0 0';
+    var path = '';
     // Do something here if not at least 3 vertices?
     for (var i = 0; i < argumentList.length; i++) {
       coordinate = argumentList[i].trim().split(/\s+/);
@@ -22,7 +22,11 @@
       if (!x || !y || x.unit === '%' || y.unit === '%') {
         return undefined;
       }
-      path += ' l ' + (x.value - previousX) + ' ' + (y.value - previousY);
+      if (i === 0) {
+        path += 'm ' + x.value + ' ' + y.value;
+      } else {
+        path += ' l ' + (x.value - previousX) + ' ' + (y.value - previousY);
+      }
       previousX = x.value;
       previousY = y.value;
     }

--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -41,9 +41,10 @@
 
     var ray = /^ray\((.*)\)$/.exec(input);
     var path = /^path\(['"](.*)['"]\)$/.exec(input);
-    if (ray === null && path === null) {
-      return undefined;
-    } else if (ray !== null) {
+    // TODO: For basic shape check for closing brackets
+    var shapeType = /^[^\(]*/.exec(input);
+
+    if (ray !== null) {
       var rayInput = ray[1].split(/\s+/);
       if (rayInput.length > 3) {
         return undefined;

--- a/test/basicShapePolygonTest.js
+++ b/test/basicShapePolygonTest.js
@@ -7,12 +7,18 @@
       var offsetPathParse = internalScope.offsetPathParse;
       var assertTransformInterpolation = internalScope.assertTransformInterpolation;
 
-      var result = offsetPathParse('polygon(150px 200px, 250px 150px, 200px -150px)');
+      var result = offsetPathParse('polygon(0px 0px, 150px 200px, 250px 150px, 200px -150px)');
       assert.equal(offsetPathParse(result.path, 'm 0 0 l 150 200 l 100 -50 l -50 -300 z'));
 
+      var result = offsetPathParse('polygon(0px 0px, 50px 0px, 50px -50px, 0px -50px)');
+      assert.equal(offsetPathParse(result.path, 'm 0 0 l 50 0 l 0 -50 l -50 0 z'));
+
+      var result = offsetPathParse('polygon(50px 0px, 50px -50px, 0px -50px)');
+      assert.equal(offsetPathParse(result.path, 'm 50 0 l 0 -50 l -50 0 z'));
+
       assertTransformInterpolation([
-                                    {'offsetPath': 'polygon(50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '0%'},
-                                    {'offsetPath': 'polygon(50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '100%'}],
+                                    {'offsetPath': 'polygon(0px 0px, 50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'polygon(0px 0px, 50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '100%'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px)'},
                                     {at: 0.25, is: 'translate3d(50px, 0px, 0px) rotate(-90deg)'},
@@ -23,8 +29,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'polygon(250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '0%'},
-                                    {'offsetPath': 'polygon(250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '100%'}],
+                                    {'offsetPath': 'polygon(0px 0px, 250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'polygon(0px 0px, 250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '100%'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px)'},
                                     {at: 1 / 3, is: 'translate3d(400px, 200px, 0px) rotate(127.04deg)'},

--- a/test/basicShapePolygonTest.js
+++ b/test/basicShapePolygonTest.js
@@ -8,7 +8,7 @@
       var assertTransformInterpolation = internalScope.assertTransformInterpolation;
 
       var result = offsetPathParse('polygon(150px 200px, 250px 150px, 200px -150px)');
-      assert.equal(offsetPathParse(result.path, 'm 0 0 h 150 v 200 h 100 v -50 h -50 v -300 z'));
+      assert.equal(offsetPathParse(result.path, 'm 0 0 l 150 200 l 100 -50 l -50 -300 z'));
 
       assertTransformInterpolation([
                                     {'offsetPath': 'polygon(50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '0%'},
@@ -27,9 +27,9 @@
                                     {'offsetPath': 'polygon(250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '100%'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px)'},
-                                    {at: 1 / 3, is: 'translate3d(400px, 200px, 0px) rotate(180deg)'},
-                                    {at: 0.5, is: 'translate3d(250px, 350px, 0px) rotate(90deg)'},
-                                    {at: 2 / 3, is: 'translate3d(0px, 400px, 0px) rotate(180deg)'},
+                                    {at: 1 / 3, is: 'translate3d(400px, 200px, 0px) rotate(127.04deg)'},
+                                    {at: 0.5, is: 'translate3d(250px, 400px, 0px) rotate(180deg)'},
+                                    {at: 2 / 3, is: 'translate3d(0px, 400px, 0px) rotate(-126.44deg)'},
                                     {at: 1, is: 'translate3d(0px, 0px, 0px)'}
         ]
       );

--- a/test/basicShapePolygonTest.js
+++ b/test/basicShapePolygonTest.js
@@ -1,0 +1,38 @@
+/* global suite test assert internalScope */
+'use strict';
+
+(function () {
+  suite('offsetPath', function () {
+    test('polygon', function () {
+      var offsetPathParse = internalScope.offsetPathParse;
+      var assertTransformInterpolation = internalScope.assertTransformInterpolation;
+
+      var result = offsetPathParse('polygon(150px 200px, 250px 150px, 200px -150px)');
+      assert.equal(offsetPathParse(result.path, 'm 0 0 h 150 v 200 h 100 v -50 h -50 v -300 z'));
+
+      assertTransformInterpolation([
+                                    {'offsetPath': 'polygon(50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'polygon(50px 0px, 50px -50px, 0px -50px)', 'offsetDistance': '100%'}],
+        [
+                                    {at: 0, is: 'translate3d(0px, 0px, 0px)'},
+                                    {at: 0.25, is: 'translate3d(50px, 0px, 0px) rotate(-90deg)'},
+                                    {at: 0.5, is: 'translate3d(50px, -50px, 0px) rotate(180deg)'},
+                                    {at: 0.75, is: 'translate3d(0px, -50px, 0px) rotate(90deg)'},
+                                    {at: 1, is: 'translate3d(0px, 0px, 0px)'}
+        ]
+      );
+
+      assertTransformInterpolation([
+                                    {'offsetPath': 'polygon(250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'polygon(250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '100%'}],
+        [
+                                    {at: 0, is: 'translate3d(0px, 0px, 0px)'},
+                                    {at: 1 / 3, is: 'translate3d(400px, 200px, 0px) rotate(180deg)'},
+                                    {at: 0.5, is: 'translate3d(250px, 350px, 0px) rotate(90deg)'},
+                                    {at: 2 / 3, is: 'translate3d(0px, 400px, 0px) rotate(180deg)'},
+                                    {at: 1, is: 'translate3d(0px, 0px, 0px)'}
+        ]
+      );
+    });
+  });
+})();

--- a/test/basicShapePolygonTest.js
+++ b/test/basicShapePolygonTest.js
@@ -10,10 +10,10 @@
       var result = offsetPathParse('polygon(0px 0px, 150px 200px, 250px 150px, 200px -150px)');
       assert.equal(offsetPathParse(result.path, 'm 0 0 l 150 200 l 100 -50 l -50 -300 z'));
 
-      var result = offsetPathParse('polygon(0px 0px, 50px 0px, 50px -50px, 0px -50px)');
+      result = offsetPathParse('polygon(0px 0px, 50px 0px, 50px -50px, 0px -50px)');
       assert.equal(offsetPathParse(result.path, 'm 0 0 l 50 0 l 0 -50 l -50 0 z'));
 
-      var result = offsetPathParse('polygon(50px 0px, 50px -50px, 0px -50px)');
+      result = offsetPathParse('polygon(50px 0px, 50px -50px, 0px -50px)');
       assert.equal(offsetPathParse(result.path, 'm 50 0 l 0 -50 l -50 0 z'));
 
       assertTransformInterpolation([

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -86,7 +86,6 @@
       animation.currentTime = at;
       var result = target.style._getAnimated(propertyToRead);
       animation.cancel();
-
       assert.equal(result, is, 'For: ' + JSON.stringify(keyframes) + ' at: ' + at + '\n');
     }
   }

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -86,6 +86,7 @@
       animation.currentTime = at;
       var result = target.style._getAnimated(propertyToRead);
       animation.cancel();
+
       assert.equal(result, is, 'For: ' + JSON.stringify(keyframes) + ' at: ' + at + '\n');
     }
   }


### PR DESCRIPTION
No support for fill-rule or percentages. 
I am also suspicious of the last test in test/basicShapePolygonTest.js. At 0.5 I was expecting the transform to be 'translate3d(250px, 400px, 0px) rotate(90deg)'. This is because I have purposely made the polygon to be a hexagon with sides of length 250px. However when I console.log the path length it returns 1800, not 1500.