### PR TITLE
Support for offset-path circle string

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,7 +23,8 @@ module.exports = function(config) {
         'tools/internal-scope.js',
       ],
       require('fs').readFileSync('src/fileOrder.txt', 'utf8').split('\n'),
-      ['test/*.js']
+      //['test/*.js']
+      ['test/testFunctions.js', 'test/pathBasicShapeCircleTest.js']
     ),
 
     // list of files to exclude

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,8 +23,7 @@ module.exports = function(config) {
         'tools/internal-scope.js',
       ],
       require('fs').readFileSync('src/fileOrder.txt', 'utf8').split('\n'),
-      //['test/*.js']
-      ['test/testFunctions.js', 'test/pathBasicShapeCircleTest.js']
+      ['test/*.js']
     ),
 
     // list of files to exclude

--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -34,6 +34,40 @@
     return {type: 'path', path: path};
   }
 
+  function basicShapeInset(input) {
+    // WIP
+    return null;
+  }
+
+  function basicShapeCircle(input) {
+    var radius;
+    var position = /at (.*?)$/.exec(input);
+
+    if(position === null) {
+      position = ['0px', '0px'];
+      if(input !== '') {
+        radius = input; 
+      }
+    } else {
+      position = position[1].split(/\s+/);
+      radius = (/^(.*?) at/.exec(input));
+      if(radius === null) {
+        radius = 'closest-side';
+      } else { 
+        radius = radius[1];
+      }
+    }
+
+    radius = Number(radius.substring(0, radius.length - 2));
+    //console.log("radius: " + radius + '\n\tpostion: ' + position);
+    return {type: 'circle', path: {radius: {value: radius, unit: 'px'}, position: position}};
+  }
+
+  function basicShapeEllipse(input) {
+    // WIP
+    return null;
+  }
+
   function offsetPathParse (input) {
     var parseAngleAsDegrees = internalScope.parseAngleAsDegrees;
     var isInArray = internalScope.isInArray;
@@ -90,8 +124,13 @@
       }
 
       var shapeArguments = /\(([^)]+)\)/.exec(input);
+
       if (shapeType[0] === 'polygon') {
         return basicShapePolygon(shapeArguments[1]);
+      }
+
+      if(shapeType[0] === 'circle') {
+        return basicShapeCircle(shapeArguments[1]);
       }
     }
   }

--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -34,36 +34,47 @@
     return {type: 'path', path: path};
   }
 
-  function basicShapeInset(input) {
+  function basicShapeInset (input) {
     // WIP
     return null;
   }
 
-  function basicShapeCircle(input) {
+  function basicShapeCircle (input) {
+    // TODO: Need element as an argument to this function
     var radius;
     var position = /at (.*?)$/.exec(input);
 
-    if(position === null) {
-      position = ['0px', '0px'];
-      if(input !== '') {
-        radius = input; 
+    // TODO: Need to support other positions as currently this only supports positions in which both x and y are specified and are in px
+    if (position === null) {
+      // TODO: Set default position to the center of the reference box
+      position = [0, 0];
+      if (input !== '') {
+        radius = input;
       }
     } else {
       position = position[1].split(/\s+/);
       radius = (/^(.*?) at/.exec(input));
-      if(radius === null) {
+      if (radius === null) {
         radius = 'closest-side';
-      } else { 
+      } else {
         radius = radius[1];
       }
     }
 
     radius = Number(radius.substring(0, radius.length - 2));
-    //console.log("radius: " + radius + '\n\tpostion: ' + position);
-    return {type: 'circle', path: {radius: {value: radius, unit: 'px'}, position: position}};
+
+    var positionX = Number(position[0].substring(0, position[0].length - 2));
+    var positionY = Number(position[1].substring(0, position[1].length - 2));
+
+    var pathString = 'M ' + positionX + ' ' + positionY +
+                      ' m 0,' + (-radius) +
+                      ' a ' + radius + ',' + radius + ' 0 0,1 ' + radius + ',' + radius +
+                      ' a ' + radius + ',' + radius + ' 0 1,1 ' + (-radius) + ',' + (-radius) + ' z';
+
+    return {type: 'path', path: pathString};
   }
 
-  function basicShapeEllipse(input) {
+  function basicShapeEllipse (input) {
     // WIP
     return null;
   }
@@ -125,12 +136,20 @@
 
       var shapeArguments = /\(([^)]+)\)/.exec(input);
 
-      if (shapeType[0] === 'polygon') {
-        return basicShapePolygon(shapeArguments[1]);
+      if (shapeType[0] === 'inset') {
+        return basicShapeInset(shapeArguments[1]);
       }
 
-      if(shapeType[0] === 'circle') {
+      if (shapeType[0] === 'circle') {
         return basicShapeCircle(shapeArguments[1]);
+      }
+
+      if (shapeType[0] === 'ellipse') {
+        return basicShapeEllipse(shapeArguments[1]);
+      }
+
+      if (shapeType[0] === 'polygon') {
+        return basicShapePolygon(shapeArguments[1]);
       }
     }
   }
@@ -151,6 +170,7 @@
       if (input.type === 'path') {
         return "path('" + input.path + "')";
       }
+
       if (input.type === null) {
         return 'none';
       }

--- a/src/toTransform.js
+++ b/src/toTransform.js
@@ -52,6 +52,10 @@
     if (offsetPath.type === 'ray') {
       return convertRayString(properties, positionAnchor);
     }
+
+    if (offsetPath.type === 'circle') {
+      return convertCircleString(properties);
+    }
   }
 
   function getOffsetDistanceLength (offsetDistance, pathLength, epsilon) {
@@ -155,6 +159,33 @@
     return {deltaX: roundToHundredth(deltaX),
             deltaY: roundToHundredth(deltaY),
             rotation: (offsetPath.angle - 90)};
+  }
+
+
+  function convertCircleString(properties) {
+    var offsetPath = internalScope.offsetPathParse(properties['offsetPath']);
+    var offsetDistance = internalScope.offsetDistanceParse(properties['offsetDistance']);
+    
+    var radius = offsetPath.path.radius.value;
+    var pathTotalLength = 2 * Math.PI * radius;
+    if (offsetDistance === undefined) {
+      offsetDistance = {value: 0, unit: 'px'};
+    }
+    
+    var angle;
+    if(offsetDistance.unit === 'px') {
+      angle = 360 * (offsetDistance.value / pathTotalLength) * Math.PI / 180;
+    } else if(offsetDistance.unit === '%') {
+      angle = 360 * (offsetDistance.value / 100) * Math.PI / 180;
+    }
+    // console.log("Angle: "  + (angle * 180/Math.PI));
+    
+    var deltaX = Math.sin(angle) * radius;
+    var deltaY = (-1) * Math.cos(angle) * radius;
+
+    return {deltaX: roundToHundredth(deltaX),
+            deltaY: roundToHundredth(deltaY),
+            rotation: 0}; // Rotation tangent to the circle?? 
   }
 
   function convertOffsetAnchorPosition (properties, element) {

--- a/src/toTransform.js
+++ b/src/toTransform.js
@@ -106,7 +106,7 @@
 
     var currentOffsetDistance = getPathStringOffsetDistance(offsetPath, pathElement, offsetDistance, 0);
 
-    var epsilon = 0.001;
+    var epsilon = 0.0001;
     var rotateFlip = false;
     if (!closedLoop && (currentOffsetDistance + epsilon) > totalPathLength) {
       epsilon *= -1;

--- a/src/toTransform.js
+++ b/src/toTransform.js
@@ -52,10 +52,6 @@
     if (offsetPath.type === 'ray') {
       return convertRayString(properties, positionAnchor);
     }
-
-    if (offsetPath.type === 'circle') {
-      return convertCircleString(properties);
-    }
   }
 
   function getOffsetDistanceLength (offsetDistance, pathLength, epsilon) {
@@ -159,33 +155,6 @@
     return {deltaX: roundToHundredth(deltaX),
             deltaY: roundToHundredth(deltaY),
             rotation: (offsetPath.angle - 90)};
-  }
-
-
-  function convertCircleString(properties) {
-    var offsetPath = internalScope.offsetPathParse(properties['offsetPath']);
-    var offsetDistance = internalScope.offsetDistanceParse(properties['offsetDistance']);
-    
-    var radius = offsetPath.path.radius.value;
-    var pathTotalLength = 2 * Math.PI * radius;
-    if (offsetDistance === undefined) {
-      offsetDistance = {value: 0, unit: 'px'};
-    }
-    
-    var angle;
-    if(offsetDistance.unit === 'px') {
-      angle = 360 * (offsetDistance.value / pathTotalLength) * Math.PI / 180;
-    } else if(offsetDistance.unit === '%') {
-      angle = 360 * (offsetDistance.value / 100) * Math.PI / 180;
-    }
-    // console.log("Angle: "  + (angle * 180/Math.PI));
-    
-    var deltaX = Math.sin(angle) * radius;
-    var deltaY = (-1) * Math.cos(angle) * radius;
-
-    return {deltaX: roundToHundredth(deltaX),
-            deltaY: roundToHundredth(deltaY),
-            rotation: 0}; // Rotation tangent to the circle?? 
   }
 
   function convertOffsetAnchorPosition (properties, element) {

--- a/test/basicShapePolygonTest.js
+++ b/test/basicShapePolygonTest.js
@@ -33,9 +33,9 @@
                                     {'offsetPath': 'polygon(0px 0px, 250px 0px, 400px 200px, 250px 400px, 0px 400px, -150px 200px)', 'offsetDistance': '100%'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px)'},
-                                    {at: 1 / 3, is: 'translate3d(400px, 200px, 0px) rotate(127.04deg)'},
+                                    {at: 1 / 3, is: 'translate3d(400px, 200px, 0px) rotate(128.66deg)'},
                                     {at: 0.5, is: 'translate3d(250px, 400px, 0px) rotate(180deg)'},
-                                    {at: 2 / 3, is: 'translate3d(0px, 400px, 0px) rotate(-126.44deg)'},
+                                    {at: 2 / 3, is: 'translate3d(0px, 400px, 0px) rotate(-128.66deg)'},
                                     {at: 1, is: 'translate3d(0px, 0px, 0px)'}
         ]
       );

--- a/test/offsetPathDistanceTest.js
+++ b/test/offsetPathDistanceTest.js
@@ -1,7 +1,7 @@
 /* global suite test internalScope */
 
 (function () {
-  suite('transforms', function () {
+  suite('offsetPath', function () {
     test('offsetPathDistance', function () {
       var assertTransformInterpolation = internalScope.assertTransformInterpolation;
 
@@ -170,10 +170,10 @@
                                     {'offsetPath': "path('M 0, 100 L 50, 150 L -50, 150 L 0, 100')", 'offsetDistance': '0%'},
                                     {'offsetPath': "path('M 0, 100 L 50, 150 L -50, 150 L 0, 100')", 'offsetDistance': '100%'}],
         [
-                                    {at: 0, is: 'translate3d(0px, 100px, 0px) rotate(45.1deg)'},
+                                    {at: 0, is: 'translate3d(0px, 100px, 0px) rotate(44.16deg)'},
                                     {at: 1 / 3, is: 'translate3d(40.24px, 150px, 0px) rotate(180deg)'},
                                     {at: 2 / 3, is: 'translate3d(-40.24px, 150px, 0px) rotate(180deg)'},
-                                    {at: 1, is: 'translate3d(0px, 100px, 0px) rotate(314.85deg)'}
+                                    {at: 1, is: 'translate3d(0px, 100px, 0px) rotate(315deg)'}
         ]
       );
 
@@ -182,9 +182,9 @@
                                     {'offsetPath': "path('M 0, 0 L -50, 86.6 150 L 50, 86.6 L 0, 0')", 'offsetDistance': '100%'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(120deg)'},
-                                    {at: 1 / 3, is: 'translate3d(-16.67px, 28.87px, 0px) rotate(119.99deg)'},
-                                    {at: 2 / 3, is: 'translate3d(-33.33px, 57.73px, 0px) rotate(119.99deg)'},
-                                    {at: 1, is: 'translate3d(-50px, 86.6px, 0px) rotate(119.88deg)'}
+                                    {at: 1 / 3, is: 'translate3d(-16.67px, 28.87px, 0px) rotate(120.02deg)'},
+                                    {at: 2 / 3, is: 'translate3d(-33.33px, 57.73px, 0px) rotate(119.48deg)'},
+                                    {at: 1, is: 'translate3d(-50px, 86.6px, 0px) rotate(120.58deg)'}
         ]
       );
 

--- a/test/pathBasicShapeCircleTest.js
+++ b/test/pathBasicShapeCircleTest.js
@@ -1,0 +1,22 @@
+/* global suite test internalScope */
+
+(function () {
+  suite('transforms', function () {
+    test('basicShapeCircle', function () {
+      var assertTransformInterpolation = internalScope.assertTransformInterpolation;
+
+      assertTransformInterpolation([
+                                    {'offsetPath': "circle(10px at 0px 0px)", 'offsetDistance': '0%'},
+                                    {'offsetPath': "circle(10px at 0px 0px)", 'offsetDistance': '100%'}],
+        [
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px)'},
+                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px)'},
+                                    {at: 0.5, is: 'translate3d(0px, 10px, 0px)'},
+                                    {at: 0.75, is: 'translate3d(-10px, 0px, 0px)'},
+                                    {at: 1, is: 'translate3d(0px, -10px, 0px)'}
+        ]
+      );
+
+    });
+  });
+})();

--- a/test/pathBasicShapeCircleTest.js
+++ b/test/pathBasicShapeCircleTest.js
@@ -1,7 +1,7 @@
 /* global suite test internalScope */
 
 (function () {
-  suite('transforms', function () {
+  suite('offsetPath', function () {
     test('basicShapeCircle', function () {
       var assertTransformInterpolation = internalScope.assertTransformInterpolation;
 
@@ -9,11 +9,11 @@
                                     {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0%'},
                                     {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '100%'}],
         [
-                                    {at: 0, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'},
-                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px) rotate(90.27deg)'},
-                                    {at: 0.5, is: 'translate3d(0px, 10px, 0px) rotate(-179.73deg)'},
-                                    {at: 0.75, is: 'translate3d(-10px, 0px, 0px) rotate(-89.73deg)'},
-                                    {at: 1, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'}
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px)'},
+                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px) rotate(90deg)'},
+                                    {at: 0.5, is: 'translate3d(0px, 10px, 0px) rotate(180deg)'},
+                                    {at: 0.75, is: 'translate3d(-10px, 0px, 0px) rotate(-90deg)'},
+                                    {at: 1, is: 'translate3d(0px, -10px, 0px)'}
         ]
         );
 
@@ -21,11 +21,21 @@
                                     {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0px'},
                                     {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '62.83px'}],
         [
-                                    {at: 0, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'},
-                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px) rotate(89.84deg)'},
-                                    {at: 0.5, is: 'translate3d(0.01px, 10px, 0px) rotate(179.84deg)'},
-                                    {at: 0.75, is: 'translate3d(-10px, 0.01px, 0px) rotate(-90.16deg)'},
-                                    {at: 1, is: 'translate3d(-0.01px, -10px, 0px) rotate(-0.16deg)'}
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px)'},
+                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px) rotate(89.45deg)'},
+                                    {at: 0.5, is: 'translate3d(0.01px, 10px, 0px) rotate(180deg)'},
+                                    {at: 0.75, is: 'translate3d(-10px, 0.01px, 0px) rotate(-90deg)'},
+                                    {at: 1, is: 'translate3d(-0.01px, -10px, 0px) rotate(-0.55deg)'}
+        ]
+        );
+
+      assertTransformInterpolation([
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '50%'}],
+        [
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px)'},
+                                    {at: 0.5, is: 'translate3d(10px, 0px, 0px) rotate(90deg)'},
+                                    {at: 1, is: 'translate3d(0px, 10px, 0px) rotate(180deg)'}
         ]
         );
 
@@ -33,10 +43,21 @@
                                     {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0px'},
                                     {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '31.42px'}],
         [
-                                    {at: 0, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'},
-                                    {at: 0.5, is: 'translate3d(10px, 0px, 0px) rotate(90.22deg)'},
-                                    {at: 1, is: 'translate3d(0px, 10px, 0px) rotate(-179.84deg)'}
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px)'},
+                                    {at: 0.5, is: 'translate3d(10px, 0px, 0px) rotate(90deg)'},
+                                    {at: 1, is: 'translate3d(0px, 10px, 0px) rotate(179.45deg)'}
+        ]
+        );
 
+      assertTransformInterpolation([
+                                    {'offsetPath': 'circle(10px at 100px 100px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'circle(10px at 100px 100px)', 'offsetDistance': '100%'}],
+        [
+                                    {at: 0, is: 'translate3d(100px, 90px, 0px)'},
+                                    {at: 0.25, is: 'translate3d(110px, 100px, 0px) rotate(90deg)'},
+                                    {at: 0.5, is: 'translate3d(100px, 110px, 0px) rotate(180deg)'},
+                                    {at: 0.75, is: 'translate3d(90px, 100px, 0px) rotate(-90deg)'},
+                                    {at: 1, is: 'translate3d(100px, 90px, 0px)'}
         ]
         );
     });

--- a/test/pathBasicShapeCircleTest.js
+++ b/test/pathBasicShapeCircleTest.js
@@ -6,17 +6,39 @@
       var assertTransformInterpolation = internalScope.assertTransformInterpolation;
 
       assertTransformInterpolation([
-                                    {'offsetPath': "circle(10px at 0px 0px)", 'offsetDistance': '0%'},
-                                    {'offsetPath': "circle(10px at 0px 0px)", 'offsetDistance': '100%'}],
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '100%'}],
         [
-                                    {at: 0, is: 'translate3d(0px, -10px, 0px)'},
-                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px)'},
-                                    {at: 0.5, is: 'translate3d(0px, 10px, 0px)'},
-                                    {at: 0.75, is: 'translate3d(-10px, 0px, 0px)'},
-                                    {at: 1, is: 'translate3d(0px, -10px, 0px)'}
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'},
+                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px) rotate(90.27deg)'},
+                                    {at: 0.5, is: 'translate3d(0px, 10px, 0px) rotate(-179.73deg)'},
+                                    {at: 0.75, is: 'translate3d(-10px, 0px, 0px) rotate(-89.73deg)'},
+                                    {at: 1, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'}
         ]
-      );
+        );
 
+      assertTransformInterpolation([
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '62.83px'}],
+        [
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'},
+                                    {at: 0.25, is: 'translate3d(10px, 0px, 0px) rotate(89.84deg)'},
+                                    {at: 0.5, is: 'translate3d(0.01px, 10px, 0px) rotate(179.84deg)'},
+                                    {at: 0.75, is: 'translate3d(-10px, 0.01px, 0px) rotate(-90.16deg)'},
+                                    {at: 1, is: 'translate3d(-0.01px, -10px, 0px) rotate(-0.16deg)'}
+        ]
+        );
+
+      assertTransformInterpolation([
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'circle(10px at 0px 0px)', 'offsetDistance': '31.42px'}],
+        [
+                                    {at: 0, is: 'translate3d(0px, -10px, 0px) rotate(0.27deg)'},
+                                    {at: 0.5, is: 'translate3d(10px, 0px, 0px) rotate(90.22deg)'},
+                                    {at: 1, is: 'translate3d(0px, 10px, 0px) rotate(-179.84deg)'}
+
+        ]
+        );
     });
   });
 })();


### PR DESCRIPTION
Currently only supports the case for when both a radius and position have been provided and also when both the x and y components of the given position have been specified. 

Only supports radius and position when specified in px.