### PR TITLE
Update to latest versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "karma": "^1.3.0",
+    "chai": "^4.0.2",
+    "karma": "^1.7.0",
     "karma-chai": "^0.1.0",
-    "karma-firefox-launcher": "^1.0.0",
+    "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
-    "karma-nyan-reporter": "^0.2.4",
-    "mocha": "^3.2.0",
-    "semistandard": "~9.1.0",
-    "uglifyjs": "^2.4.10"
+    "karma-nyan-reporter": "^0.2.5",
+    "mocha": "^3.4.2",
+    "semistandard": "~11.0.0",
+    "uglify-js": "^3.0.15"
   },
   "repository": {
     "type": "git",

--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -152,7 +152,7 @@
 
   function parseShape (input, element) {
     var isInArray = internalScope.isInArray;
-    var shapeType = /^[^\(]*/.exec(input);
+    var shapeType = /^[^(]*/.exec(input);
     if (shapeType == null) {
       return undefined;
     }

--- a/src/offsetRotate.js
+++ b/src/offsetRotate.js
@@ -76,4 +76,3 @@
   internalScope.offsetRotateParse = offsetRotateParse;
   internalScope.offsetRotateMerge = offsetRotateMerge;
 })();
-

--- a/src/toTransform.js
+++ b/src/toTransform.js
@@ -152,9 +152,10 @@
     var deltaX = Math.sin(offsetPath.angle * Math.PI / 180) * offsetDistanceLength;
     var deltaY = (-1) * Math.cos(offsetPath.angle * Math.PI / 180) * offsetDistanceLength;
 
-    return {deltaX: roundToHundredth(deltaX),
-            deltaY: roundToHundredth(deltaY),
-            rotation: (offsetPath.angle - 90)};
+    return {
+      deltaX: roundToHundredth(deltaX),
+      deltaY: roundToHundredth(deltaY),
+      rotation: (offsetPath.angle - 90)};
   }
 
   function convertOffsetAnchorPosition (properties, element) {
@@ -193,7 +194,7 @@
     var offsetLeft = element.offsetLeft;
     var offsetTop = element.offsetTop;
 
-    elementProperties = element.getBoundingClientRect();
+    var elementProperties = element.getBoundingClientRect();
     var parentProperties = element.offsetParent ? element.offsetParent.getBoundingClientRect() : null;
     element.style._style.transform = savedTransform;
 
@@ -207,8 +208,8 @@
         deltaY: 0,
         transformOriginX: transformOrigin[0].value,
         transformOriginY: transformOrigin[1].value,
-        offsetPosX: offsetPosX,
-        offsetPosY: offsetPosY,
+        offsetPosX: offsetLeft,
+        offsetPosY: offsetTop,
         containerWidth: parentProperties.width,
         containerHeight: parentProperties.height
       };
@@ -217,7 +218,6 @@
         result['anchorY'] = transformOrigin[1].value;
         return result;
       }
-      var elementProperties = element.getBoundingClientRect();
       if (anchor[0].unit === '%') {
         result['anchorX'] = (anchor[0].value * elementProperties.width) / 100;
       } else {

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -116,4 +116,3 @@
   internalScope.assertNoInterpolation = assertNoInterpolation;
   internalScope.assertTransform = assertTransform;
 })();
-


### PR DESCRIPTION
We have recently received errors in Travis:
> cat ... | uglifyjs > motion-path-polyfill.min.js
sh: 1: uglifyjs: not found
cat: write error: Broken pipe

We attempt to avoid these errors by upgrading to the most
recent versions of our dependencies.

We now use 'uglify-js' as the npm package 'uglifyjs' is deprecated.

Upgrading semistandard requires some minor changes to our
code. The warnings were:
> src/offsetPath.js:155:25: Unnecessary escape character: \(.
> src/offsetRotate.js:79:1: Too many blank lines at the end of file. Max of 0 allowed.
> src/toTransform.js:156:13: Expected indentation of 6 spaces but found 12.
> src/toTransform.js:157:13: Expected indentation of 6 spaces but found 12.
> src/toTransform.js:196:5: 'elementProperties' was used before it was defined.
> src/toTransform.js:210:21: 'offsetPosX' was used before it was defined.
> src/toTransform.js:211:21: 'offsetPosY' was used before it was defined.
> test/testFunctions.js:119:1: Too many blank lines at the end of file. Max of 0 allowed.
