### PR TITLE
Implement support for size = 'sides' in ray paths

### DIFF
--- a/src/offsetPath.js
+++ b/src/offsetPath.js
@@ -109,12 +109,12 @@
     if (ray === null) {
       return undefined;
     }
-    var rayInput = ray[1].split(/\s+/);
+    var rayInput = ray[1].trim().split(/\s+/);
     if (rayInput.length > 3) {
       return undefined;
     }
     var result = {type: 'ray', angle: null, path: null, contain: false, size: null};
-    var validSizes = ['closest-side', 'farthest-side', 'closest-corner', 'farthest-corner'];
+    var validSizes = ['closest-side', 'farthest-side', 'closest-corner', 'farthest-corner', 'sides'];
 
     for (var i = 0; i < rayInput.length; i++) {
       if (rayInput[i] === 'contain') {
@@ -128,7 +128,7 @@
         }
         result.size = rayInput[i];
       } else {
-        if (result.angle) {
+        if (result.angle !== null) {
           return undefined;
         }
         var rayInputDegrees = parseAngleAsDegrees(rayInput[i]);
@@ -137,6 +137,9 @@
         }
         result.angle = rayInputDegrees;
       }
+    }
+    if (result.angle === null || result.size === null) {
+      return undefined;
     }
     return result;
   }

--- a/src/rayLength.js
+++ b/src/rayLength.js
@@ -12,9 +12,7 @@
     var distLeft = Math.abs(offsetPosX);
     var distTop = Math.abs(offsetPosY);
 
-    /* If size is omitted it defaults to closest-side.
-       https://drafts.fxtf.org/motion-1/#offset-path-property */
-    if (!size || size === 'closest-side') {
+    if (size === 'closest-side') {
       return Math.min(distLeft, distTop, distRight, distBottom);
     } else if (size === 'farthest-side') {
       return Math.max(distLeft, distTop, distRight, distBottom);

--- a/src/rayLength.js
+++ b/src/rayLength.js
@@ -6,13 +6,45 @@
     return Math.sqrt(a * a + b * b);
   }
 
-  function getRayLength (size, containerWidth, containerHeight, offsetPosX, offsetPosY) {
-    var distRight = Math.abs(containerWidth - offsetPosX);
-    var distBottom = Math.abs(containerHeight - offsetPosY);
+  // Find the distance to the container edge, in the direction given
+  // by angle. The offset-position is (distLeft, distTop), and the
+  //  container size is (distLeft + distRight, distTop + distBottom).
+  function getDistanceToSides (distLeft, distTop, distRight, distBottom, angle) {
+    var sin = Math.sin(angle * Math.PI / 180);
+    var cos = Math.cos(angle * Math.PI / 180);
+    var distHorizontal;
+    if (sin >= 0) {
+      distHorizontal = distRight;
+    } else {
+      distHorizontal = distLeft;
+      sin = -sin;
+    }
+    var distVertical;
+    if (cos >= 0) {
+      distVertical = distTop;
+    } else {
+      distVertical = distBottom;
+      cos = -cos;
+    }
+    if (distVertical * sin <= distHorizontal * cos) {
+      return distVertical / cos;
+    } else {
+      return distHorizontal / sin;
+    }
+  }
+
+  function getRayLength (size, containerWidth, containerHeight, offsetPosX, offsetPosY, angle) {
     var distLeft = Math.abs(offsetPosX);
     var distTop = Math.abs(offsetPosY);
+    var distRight = Math.abs(containerWidth - offsetPosX);
+    var distBottom = Math.abs(containerHeight - offsetPosY);
 
-    if (size === 'closest-side') {
+    if (size === 'sides') {
+      if (offsetPosX <= 0 || offsetPosY <= 0 || offsetPosX >= containerWidth || offsetPosY >= containerHeight) {
+        return 0;
+      }
+      return getDistanceToSides(distLeft, distTop, distRight, distBottom, angle);
+    } else if (size === 'closest-side') {
       return Math.min(distLeft, distTop, distRight, distBottom);
     } else if (size === 'farthest-side') {
       return Math.max(distLeft, distTop, distRight, distBottom);

--- a/src/toTransform.js
+++ b/src/toTransform.js
@@ -138,7 +138,8 @@
                                              positionAnchor.containerWidth,
                                              positionAnchor.containerHeight,
                                              positionAnchor.offsetPosX,
-                                             positionAnchor.offsetPosY);
+                                             positionAnchor.offsetPosY,
+                                             offsetPath.angle);
     }
 
     var offsetDistance = internalScope.offsetDistanceParse(properties['offsetDistance']);

--- a/test/offsetPathTest.js
+++ b/test/offsetPathTest.js
@@ -9,24 +9,24 @@
 
       assertInterpolation({
         property: 'offsetPath',
-        from: 'ray(100deg)',
-        to: 'ray(-100deg)'
+        from: 'ray(100deg closest-side)',
+        to: 'ray(-100deg closest-side)'
       }, [
-        {at: 0, is: 'ray(100deg)'},
-        {at: 0.25, is: 'ray(50deg)'},
-        {at: 0.75, is: 'ray(-50deg)'},
-        {at: 1, is: 'ray(-100deg)'}
+        {at: 0, is: 'ray(100deg closest-side)'},
+        {at: 0.25, is: 'ray(50deg closest-side)'},
+        {at: 0.75, is: 'ray(-50deg closest-side)'},
+        {at: 1, is: 'ray(-100deg closest-side)'}
       ]);
 
       assertInterpolation({
         property: 'offsetPath',
-        from: 'ray(100deg contain)',
-        to: 'ray(-100deg contain)'
+        from: 'ray(100deg farthest-corner contain)',
+        to: 'ray(-100deg farthest-corner contain)'
       }, [
-        {at: 0, is: 'ray(100deg contain)'},
-        {at: 0.25, is: 'ray(50deg contain)'},
-        {at: 0.75, is: 'ray(-50deg contain)'},
-        {at: 1, is: 'ray(-100deg contain)'}
+        {at: 0, is: 'ray(100deg farthest-corner contain)'},
+        {at: 0.25, is: 'ray(50deg farthest-corner contain)'},
+        {at: 0.75, is: 'ray(-50deg farthest-corner contain)'},
+        {at: 1, is: 'ray(-100deg farthest-corner contain)'}
       ]);
 
       assertInterpolation({
@@ -42,13 +42,13 @@
 
       assertInterpolation({
         property: 'offsetPath',
-        from: 'ray(contain 100deg closest-side)',
-        to: 'ray(contain -100deg closest-side)'
+        from: 'ray( contain 100deg closest-side)',
+        to: 'ray(contain -100deg closest-side )'
       }, [
-        {at: 0, is: 'ray(contain 100deg closest-side)'},
+        {at: 0, is: 'ray( contain 100deg closest-side)'},
         {at: 0.25, is: 'ray(50deg closest-side contain)'},
         {at: 0.75, is: 'ray(-50deg closest-side contain)'},
-        {at: 1, is: 'ray(contain -100deg closest-side)'}
+        {at: 1, is: 'ray(contain -100deg closest-side )'}
       ]);
 
       assertInterpolation({
@@ -105,12 +105,12 @@
       assertNoInterpolation({
         property: 'offsetPath',
         from: 'none',
-        to: 'ray(180deg)'
+        to: 'ray(180deg closest-side)'
       });
 
       assertNoInterpolation({
         property: 'offsetPath',
-        from: 'ray(180deg)',
+        from: 'ray(180deg farthest-side)',
         to: 'none'
       });
 
@@ -128,37 +128,33 @@
 
       assertNoInterpolation({
         property: 'offsetPath',
-        from: 'ray(100deg contain)',
-        to: 'ray(-100deg)'
-      });
-
-      assertNoInterpolation({
-        property: 'offsetPath',
-        from: 'ray(0deg contain contain farthest-side closest-side 50deg 90deg)',
-        to: 'ray(10deg contain contain farthest-side closest-side 60deg 100deg)'
-      });
-
-      assertNoInterpolation({
-        property: 'offsetPath',
-        from: 'ray(0deg garbage)',
-        to: 'ray(10deg contain)'
+        from: 'ray(100deg sides contain)',
+        to: 'ray(-100deg sides)'
       });
 
       assertNoInterpolation({
         property: 'offsetPath',
         from: "path('m 0 0 h 100')",
-        to: 'ray(10deg contain)'
+        to: 'ray(10deg sides contain)'
       });
 
       assertNoInterpolation({
         property: 'offsetPath',
-        from: 'ray(farthest-side closest-side 0deg)',
-        to: 'ray(farthest-side closest-side 20deg)'
+        from: 'ray(0deg farthest-side)',
+        to: 'ray(20deg closest-side)'
       });
 
-      assert.equal(internalScope.offsetRotateParse('ray(garbage)'), undefined);
-      assert.equal(internalScope.offsetRotateParse('ray(garbagedeg)'), undefined);
-      assert.equal(internalScope.offsetRotateParse('ray(deg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(garbage)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(garbagedeg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(0deg garbage)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(deg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(deg closest-side)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(0deg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(closest-side)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(0deg closest-side 20deg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(farthest-side closest-side 0deg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(farthest-side closest-side 20deg)'), undefined);
+      assert.equal(internalScope.offsetPathParse('ray(0deg contain contain farthest-side closest-side 50deg 90deg)'), undefined);
     });
   });
 })();

--- a/test/offsetRayDistanceTest.js
+++ b/test/offsetRayDistanceTest.js
@@ -6,8 +6,8 @@
       var assertTransformInterpolation = internalScope.assertTransformInterpolation;
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(60deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(60deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(60deg closest-side)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(60deg closest-side)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(-30deg)'},
                                     {at: 1, is: 'translate3d(86.6px, -50px, 0px) rotate(-30deg)'}
@@ -15,8 +15,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(90deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(90deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(90deg farthest-side)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(90deg farthest-side)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px)'},
                                     {at: 1, is: 'translate3d(100px, 0px, 0px)'}
@@ -24,8 +24,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(135deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(135deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(135deg closest-corner)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(135deg closest-corner)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(45deg)'},
                                     {at: 1, is: 'translate3d(70.71px, 70.71px, 0px) rotate(45deg)'}
@@ -33,8 +33,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(225deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(225deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(225deg farthest-corner)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(225deg farthest-corner)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(135deg)'},
                                     {at: 1, is: 'translate3d(-70.71px, 70.71px, 0px) rotate(135deg)'}
@@ -42,8 +42,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(315deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(315deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(315deg sides)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(315deg sides)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(225deg)'},
                                     {at: 1, is: 'translate3d(-70.71px, -70.71px, 0px) rotate(225deg)'}
@@ -51,8 +51,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(420deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(420deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(420deg closest-side)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(420deg closest-side)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(330deg)'},
                                     {at: 1, is: 'translate3d(86.6px, -50px, 0px) rotate(330deg)'}
@@ -60,8 +60,8 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(-45deg)', 'offsetDistance': '0px'},
-                                    {'offsetPath': 'ray(-45deg)', 'offsetDistance': '100px'}],
+                                    {'offsetPath': 'ray(-45deg closest-side)', 'offsetDistance': '0px'},
+                                    {'offsetPath': 'ray(-45deg closest-side)', 'offsetDistance': '100px'}],
         [
                                     {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(-135deg)'},
                                     {at: 1, is: 'translate3d(-70.71px, -70.71px, 0px) rotate(-135deg)'}
@@ -69,10 +69,10 @@
       );
 
       assertTransformInterpolation([
-                                    {'offsetPath': 'ray(closest-side 135deg )', 'offsetDistance': '0%'},
+                                    {'offsetPath': 'ray(closest-side 135deg)', 'offsetDistance': '0%'},
                                     {'offsetPath': 'ray(closest-side 135deg)', 'offsetDistance': '90%'}],
         [
-                                    {at: 0, is: 'translate3d(0px, 0px, 0px)'},
+                                    {at: 0, is: 'translate3d(0px, 0px, 0px) rotate(45deg)'},
                                     {at: 1, is: 'translate3d(0px, 0px, 0px) rotate(45deg)'}
         ]
       );

--- a/test/rayLengthTest.js
+++ b/test/rayLengthTest.js
@@ -5,6 +5,7 @@
   suite('rayLength', function () {
     test('rayLength', function () {
       var getRayLength = internalScope.getRayLength;
+      var epsilon = 1e-12;
       assert.equal(getRayLength('closest-corner', 500, 300, 240, 75), Math.sqrt(63225));
       assert.equal(getRayLength('closest-corner', 320, 665, -432, 876), Math.sqrt(231145));
       assert.equal(getRayLength('closest-corner', 100, 430, -550, -10), Math.sqrt(302600));
@@ -28,6 +29,64 @@
       assert.equal(getRayLength('farthest-side', 930, 529, -483, -853), 1413);
       assert.equal(getRayLength('farthest-side', 900, 300, 450, 150), 450);
       assert.equal(getRayLength('farthest-side', 500, 500, 250, 250), 250);
+
+      assert.equal(getRayLength('sides', 20, 20, 10, 20, 0), 0);
+      assert.equal(getRayLength('sides', 20, 20, 0, 10, 90), 0);
+      assert.equal(getRayLength('sides', 20, 20, 10, 0, 180), 0);
+      assert.equal(getRayLength('sides', 20, 20, 20, 10, 270), 0);
+
+      assert.equal(getRayLength('sides', 260, 280, 120, 130, 0), 130);
+      assert.closeTo(getRayLength('sides', 260, 280, 120, 130, 45), 130 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 260, 280, 120, 130, 90), 140);
+      assert.closeTo(getRayLength('sides', 260, 280, 120, 130, 135), 140 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 260, 280, 120, 130, 180), 150);
+      assert.closeTo(getRayLength('sides', 260, 280, 120, 130, 225), 120 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 260, 280, 120, 130, 270), 120);
+      assert.closeTo(getRayLength('sides', 260, 280, 120, 130, 315), 120 * Math.sqrt(2), epsilon);
+
+      assert.equal(getRayLength('sides', 280, 260, 150, 120, 0), 120);
+      assert.closeTo(getRayLength('sides', 280, 260, 150, 120, 45), 120 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 280, 260, 150, 120, 90), 130);
+      assert.closeTo(getRayLength('sides', 280, 260, 150, 120, 135), 130 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 280, 260, 150, 120, 180), 140);
+      assert.closeTo(getRayLength('sides', 280, 260, 150, 120, 225), 140 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 280, 260, 150, 120, 270), 150);
+      assert.closeTo(getRayLength('sides', 280, 260, 150, 120, 315), 120 * Math.sqrt(2), epsilon);
+
+      assert.equal(getRayLength('sides', 260, 280, 140, 150, 0), 150);
+      assert.closeTo(getRayLength('sides', 260, 280, 140, 150, 45), 120 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 260, 280, 140, 150, 90), 120);
+      assert.closeTo(getRayLength('sides', 260, 280, 140, 150, 135), 120 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 260, 280, 140, 150, 180), 130);
+      assert.closeTo(getRayLength('sides', 260, 280, 140, 150, 225), 130 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 260, 280, 140, 150, 270), 140);
+      assert.closeTo(getRayLength('sides', 260, 280, 140, 150, 315), 140 * Math.sqrt(2), epsilon);
+
+      assert.equal(getRayLength('sides', 280, 260, 130, 140, 0), 140);
+      assert.closeTo(getRayLength('sides', 280, 260, 130, 140, 45), 140 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 280, 260, 130, 140, 90), 150);
+      assert.closeTo(getRayLength('sides', 280, 260, 130, 140, 135), 120 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 280, 260, 130, 140, 180), 120);
+      assert.closeTo(getRayLength('sides', 280, 260, 130, 140, 225), 120 * Math.sqrt(2), epsilon);
+      assert.equal(getRayLength('sides', 280, 260, 130, 140, 270), 130);
+      assert.closeTo(getRayLength('sides', 280, 260, 130, 140, 315), 130 * Math.sqrt(2), epsilon);
+
+      assert.closeTo(getRayLength('sides', 108, 115, 100, 15, 30), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 109, 115, 100, 15, 30), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 115, 108, 100, 8, 60), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 115, 109, 100, 9, 60), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 115, 108, 100, 100, 120), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 115, 109, 100, 100, 120), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 108, 115, 100, 100, 150), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 109, 115, 100, 100, 150), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 108, 115, 8, 100, 210), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 109, 115, 9, 100, 210), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 115, 108, 15, 100, 240), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 115, 109, 15, 100, 240), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 115, 108, 15, 8, 300), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 115, 109, 15, 9, 300), 10 * Math.sqrt(3), epsilon);
+      assert.closeTo(getRayLength('sides', 108, 115, 8, 15, 330), 16, epsilon);
+      assert.closeTo(getRayLength('sides', 109, 115, 9, 15, 330), 10 * Math.sqrt(3), epsilon);
     });
   });
 })();

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -95,7 +95,26 @@
     assertInterpolationHelper(keyframes, expectation, 'transform');
   }
 
+  function propertyParser (property) {
+    switch (property) {
+      case 'offsetAnchor': return internalScope.offsetPositionAnchorParse;
+      case 'offsetDistance': return internalScope.offsetDistanceParse;
+      case 'offsetPath': return internalScope.offsetPathParse;
+      case 'offsetPosition': return internalScope.offsetPositionAnchorParse;
+      case 'offsetRotate': return internalScope.offsetRotateParse;
+      case 'rotate': return internalScope.rotateParse;
+      case 'scale': return internalScope.scaleParse;
+      case 'translate': return internalScope.translateParse;
+      default: return undefined;
+    }
+  }
+
   function assertInterpolation ({property, from, to}, expectation) {
+    var parser = propertyParser(property);
+    assert(parser !== undefined);
+    assert(parser(from) !== undefined);
+    assert(parser(to) !== undefined);
+
     assertInterpolationHelper({[property]: [from, to]}, expectation, property + 'ForTesting');
   }
 

--- a/test/toTransform.js
+++ b/test/toTransform.js
@@ -118,22 +118,22 @@
     });
 
     test('offsetRotate', function () {
-      assert.equal(toTransform({offsetRotate: '20 10', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
-      assert.equal(toTransform({offsetRotate: '', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
-      assert.equal(toTransform({offsetRotate: 'garbage', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
-      assert.equal(toTransform({offsetRotate: '300degrees', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
-      assert.equal(toTransform({offsetRotate: 'threedegrees', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
-      assert.equal(toTransform({offsetRotate: '10 hello 20 30deg', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
-      assert.equal(toTransform({offsetRotate: 'garbagedeg', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: '20 10', offsetPath: 'ray(90deg closest-side)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: '', offsetPath: 'ray(90deg farthest-side)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: 'garbage', offsetPath: 'ray(90deg closest-corner)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: '300degrees', offsetPath: 'ray(90deg farthest-corner)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: 'threedegrees', offsetPath: 'ray(90deg sides)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: '10 hello 20 30deg', offsetPath: 'ray(90deg closest-side)'}), 'translate3d(0px, 0px, 0px)');
+      assert.equal(toTransform({offsetRotate: 'garbagedeg', offsetPath: 'ray(90deg farthest-side)'}), 'translate3d(0px, 0px, 0px)');
       assert.equal(toTransform({offsetRotate: '100deg'}), 'none'); // no path specified
 
       var expectedDeg = 100 * (180 / Math.PI);
-      assert.equal(toTransform({offsetRotate: '100rad', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px) rotate(' + expectedDeg + 'deg)');
-      assert.equal(toTransform({offsetRotate: '15turn', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px) rotate(5400deg)');
-      assert.equal(toTransform({offsetRotate: '200deg', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px) rotate(200deg)');
-      assert.equal(toTransform({offsetRotate: '20grad', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px) rotate(18deg)');
+      assert.equal(toTransform({offsetRotate: '100rad', offsetPath: 'ray(90deg closest-side)'}), 'translate3d(0px, 0px, 0px) rotate(' + expectedDeg + 'deg)');
+      assert.equal(toTransform({offsetRotate: '15turn', offsetPath: 'ray(90deg farthest-side)'}), 'translate3d(0px, 0px, 0px) rotate(5400deg)');
+      assert.equal(toTransform({offsetRotate: '200deg', offsetPath: 'ray(90deg closest-corner)'}), 'translate3d(0px, 0px, 0px) rotate(200deg)');
+      assert.equal(toTransform({offsetRotate: '20grad', offsetPath: 'ray(90deg farthest-corner)'}), 'translate3d(0px, 0px, 0px) rotate(18deg)');
       expectedDeg = 164 * (180 / Math.PI);
-      assert.equal(toTransform({offsetRotate: '164rad', offsetPath: 'ray(90deg)'}), 'translate3d(0px, 0px, 0px) rotate(' + expectedDeg + 'deg)');
+      assert.equal(toTransform({offsetRotate: '164rad', offsetPath: 'ray(90deg sides)'}), 'translate3d(0px, 0px, 0px) rotate(' + expectedDeg + 'deg)');
     });
 
     test('rayLength', function () {


### PR DESCRIPTION
size argument of ray function is required

When the size is 'sides', the length of the ray depends on the
angle of the ray. The length is only non-zero when the
offset-position is within the containing box.

All property values used in interpolation tests are now verified
to parse successfully. Previously, some parseNoInterpolation tests
could pass accidentally because invalid values were passed.

ray parsing now succeeds even if there is leading or trailing
whitespace in the arguments.
    
Spec:
https://drafts.fxtf.org/motion-1/#offset-path-ray

