### PR TITLE
Parse offset-position and offset-anchor correctly

### DIFF
--- a/src/offsetPositionAnchor.js
+++ b/src/offsetPositionAnchor.js
@@ -7,9 +7,16 @@
 
      spec for the offset-position property:
      https://drafts.fxtf.org/motion-1/#offset-position-property
+
+     Sytax of <position>:
+     https://drafts.csswg.org/css-values-4/#typedef-position
+
+     We don't support calc expressions because these are not required
+     to demonstrate how the properties work. Thus the implicit calc
+     expressions right <length> and bottom <length> are not supported.
+     right <percentage> and bottom <percentage> are fine.
   */
   function offsetPositionAnchorParse (input) {
-    // TODO: add support for the full range of <position> values in the grammar.
     if (input === undefined) {
       return null;
     }
@@ -18,18 +25,109 @@
       return input;
     }
 
-    var values = input.split(/\s+/);
-    if (values.length !== 2) {
-      // if the input is not auto, there must be 2 distances.
+    var values = input.trim().split(/\s+/);
+    if (values.length === 1) {
+      return parseOneValuePosition(values[0]);
+    } else if (values.length === 2) {
+      return parseTwoValuePosition(values[0], values[1]);
+    } else if (values.length === 4) {
+      return parseFourValuePosition(values[0], values[1], values[2], values[3]);
+    } else {
       return undefined;
     }
+  }
 
-    var result = values.map(internalScope.offsetDistanceParse);
-    if (typeof result[0] === 'undefined' || typeof result[1] === 'undefined') {
-      return undefined;
+  function parseOneValuePosition (value) {
+    // "If only one value is specified, the second value is assumed to be ‘center’."
+    // https://drafts.csswg.org/css-backgrounds-3/#background-position
+
+    return parseTwoValuePosition(value, 'center');
+  }
+
+  function parseTwoValuePosition (first, second) {
+    if (first === 'top' || first === 'bottom' || second === 'left' || second === 'right') {
+      // Normalize so left|right appear first and/or top|bottom appear last.
+      // The position is only valid if there is one vertical value and one
+      // horizontal value, and both are keywords (not length-percentage).
+      if (!internalScope.isInArray(['top', 'center', 'bottom'], first) ||
+          !internalScope.isInArray(['left', 'center', 'right'], second)) {
+        return undefined;
+      }
+      // We received [ top | center | bottom ] [ left | center | right ]
+      var temp = first;
+      first = second;
+      second = temp;
     }
 
-    return result;
+    // We have
+    // [ left | center | right | <length-percentage> ]
+    // [ top | center | bottom | <length-percentage> ]
+
+    if (first === 'left') {
+      first = '0%';
+    } else if (first === 'center') {
+      first = '50%';
+    } else if (first === 'right') {
+      first = '100%';
+    }
+
+    if (second === 'top') {
+      second = '0%';
+    } else if (second === 'center') {
+      second = '50%';
+    } else if (second === 'bottom') {
+      second = '100%';
+    }
+
+    var leftValue = internalScope.offsetDistanceParse(first);
+    var topValue = internalScope.offsetDistanceParse(second);
+    if (typeof leftValue === 'undefined' || typeof topValue === 'undefined') {
+      return undefined;
+    }
+    return [leftValue, topValue];
+  }
+
+  function parseFourValuePosition (first, second, third, fourth) {
+    // Normalize so left|right appear first.
+    if (first === 'top' || first === 'bottom') {
+      if (!internalScope.isInArray(['left', 'right'], third)) {
+        return undefined;
+      }
+      // We received [ top | bottom ] <length-percentage> [ left | right ] <length-percentage>
+      return parseFourValuePosition(third, fourth, first, second);
+    }
+
+    // We have [ left | right ] <length-percentage> [ top | bottom ] <length-percentage>
+
+    var leftValue;
+    if (first === 'left') {
+      leftValue = internalScope.offsetDistanceParse(second);
+    } else if (first === 'right') {
+      leftValue = mirror(internalScope.offsetDistanceParse(second));
+    }
+
+    var topValue;
+    if (third === 'top') {
+      topValue = internalScope.offsetDistanceParse(fourth);
+    } else if (third === 'bottom') {
+      topValue = mirror(internalScope.offsetDistanceParse(fourth));
+    }
+
+    if (typeof leftValue === 'undefined' || typeof topValue === 'undefined') {
+      return undefined;
+    }
+    return [leftValue, topValue];
+  }
+
+  function mirror (distance) {
+    if (typeof distance === 'undefined') {
+      return undefined;
+    }
+    if (distance.unit !== '%') {
+      // Implicit calc expression [right | bottom] not supported.
+      return undefined;
+    }
+    return {value: 100 - distance.value, unit: '%'};
   }
 
   function offsetPositionAnchorMerge (start, end) {

--- a/test/offsetAnchorTest.js
+++ b/test/offsetAnchorTest.js
@@ -9,12 +9,12 @@
       assertInterpolation({
         property: 'offsetAnchor',
         from: '10% 20%',
-        to: '60% 40%'
+        to: '60%'
       }, [
         {at: 0, is: '10% 20%'},
-        {at: 0.3, is: '25% 26%'},
-        {at: 0.6, is: '40% 32%'},
-        {at: 1, is: '60% 40%'}
+        {at: 0.3, is: '25% 29%'},
+        {at: 0.6, is: '40% 38%'},
+        {at: 1, is: '60%'}
       ]);
 
       assertInterpolation({
@@ -52,10 +52,10 @@
 
       assertInterpolation({
         property: 'offsetAnchor',
-        from: '20px 50%',
+        from: 'bottom 50% left 20px',
         to: '30% 40px'
       }, [
-        {at: 0, is: '20px 50%'},
+        {at: 0, is: 'bottom 50% left 20px'},
         {at: 0.3, is: '20px 50%'},
         {at: 0.6, is: '30% 40px'},
         {at: 1, is: '30% 40px'}
@@ -63,13 +63,35 @@
 
       assertInterpolation({
         property: 'offsetAnchor',
-        from: '20px 50%',
+        from: '20px',
         to: '30px 40%'
       }, [
-        {at: 0, is: '20px 50%'},
+        {at: 0, is: '20px'},
         {at: 0.3, is: '23px 47%'},
         {at: 0.6, is: '26px 44%'},
         {at: 1, is: '30px 40%'}
+      ]);
+
+      assertInterpolation({
+        property: 'offsetAnchor',
+        from: 'bottom',
+        to: 'left'
+      }, [
+        {at: 0, is: 'bottom'},
+        {at: 0.3, is: '35% 85%'},
+        {at: 0.6, is: '20% 70%'},
+        {at: 1, is: 'left'}
+      ]);
+
+      assertInterpolation({
+        property: 'offsetAnchor',
+        from: 'right',
+        to: 'top'
+      }, [
+        {at: 0, is: 'right'},
+        {at: 0.3, is: '85% 35%'},
+        {at: 0.6, is: '70% 20%'},
+        {at: 1, is: 'top'}
       ]);
 
       assert.equal(internalScope.offsetPositionAnchorParse('garbage% pants%'), undefined);

--- a/test/offsetPositionTest.js
+++ b/test/offsetPositionTest.js
@@ -20,20 +20,20 @@
       assertInterpolation({
         property: 'offsetPosition',
         from: 'auto',
-        to: '80% 30%'
+        to: 'top 30% right 20%'
       }, [
         {at: 0, is: 'auto'},
         {at: 0.3, is: 'auto'},
         {at: 0.6, is: '80% 30%'},
-        {at: 1, is: '80% 30%'}
+        {at: 1, is: 'top 30% right 20%'}
       ]);
 
       assertInterpolation({
         property: 'offsetPosition',
-        from: '15% 73%',
+        from: 'left 15% bottom 27%',
         to: 'auto'
       }, [
-        {at: 0, is: '15% 73%'},
+        {at: 0, is: 'left 15% bottom 27%'},
         {at: 0.3, is: '15% 73%'},
         {at: 0.6, is: 'auto'},
         {at: 1, is: 'auto'}
@@ -53,29 +53,84 @@
       assertInterpolation({
         property: 'offsetPosition',
         from: '20px 50%',
-        to: '30% 40px'
+        to: 'right 70% top 40px'
       }, [
         {at: 0, is: '20px 50%'},
         {at: 0.3, is: '20px 50%'},
         {at: 0.6, is: '30% 40px'},
-        {at: 1, is: '30% 40px'}
+        {at: 1, is: 'right 70% top 40px'}
       ]);
 
       assertInterpolation({
         property: 'offsetPosition',
         from: '20px 50%',
-        to: '30px 40%'
+        to: 'left 30px top 40%'
       }, [
         {at: 0, is: '20px 50%'},
         {at: 0.3, is: '23px 47%'},
         {at: 0.6, is: '26px 44%'},
-        {at: 1, is: '30px 40%'}
+        {at: 1, is: 'left 30px top 40%'}
       ]);
+
+      assertInterpolation({
+        property: 'offsetPosition',
+        from: '40% bottom',
+        to: 'right 20%'
+      }, [
+        {at: 0, is: '40% bottom'},
+        {at: 0.3, is: '58% 76%'},
+        {at: 0.6, is: '76% 52%'},
+        {at: 1, is: 'right 20%'}
+      ]);
+
+      assertInterpolation({
+        property: 'offsetPosition',
+        from: 'top center',
+        to: 'center left'
+      }, [
+        {at: 0, is: 'top center'},
+        {at: 0.3, is: '35% 15%'},
+        {at: 0.6, is: '20% 30%'},
+        {at: 1, is: 'center left'}
+      ]);
+
+      assertInterpolation({
+        property: 'offsetPosition',
+        from: '  10% 20px',
+        to: '60%  40px  '
+      }, [
+        {at: 0, is: '  10% 20px'},
+        {at: 0.3, is: '25% 26px'},
+        {at: 0.6, is: '40% 32px'},
+        {at: 1, is: '60%  40px  '}
+      ]);
+
+      // Implicit calc values (100% - 1px) and (100% - 2px) are not supported.
+      assert.equal(internalScope.offsetPositionAnchorParse('right 1px top 2%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('left 1% bottom 2px'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('(100% - 1px) (100% - 2px)'), undefined);
 
       assert.equal(internalScope.offsetPositionAnchorParse('garbage% pants%'), undefined);
       assert.equal(internalScope.offsetPositionAnchorParse('garbage pants'), undefined);
       assert.equal(internalScope.offsetPositionAnchorParse('30% 40% 60%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('1px 2px 3px 4px 5px'), undefined);
       assert.equal(internalScope.offsetPositionAnchorParse('%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('center 1px top 2%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('left 1px center 2%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('top 1px bottom 2%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('left 1px right 2%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('left garbage top 4px'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('left 2% top garbage'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('top 4px right garbage'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('bottom garbage left 2%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('garbage 5% top 30px'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('right 5% garbage 30px'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('top 10px'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('bottom 20%'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('30px left'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('40% right'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('left right'), undefined);
+      assert.equal(internalScope.offsetPositionAnchorParse('bottom bottom'), undefined);
     });
   });
 })();


### PR DESCRIPTION
We previously only supported
\<length-percentage> \<length-percentage>

We now support all the values in
https://drafts.csswg.org/css-values-4/#typedef-position

with 2 exceptions:
1. We still don't support calc expressions, or units other than px and %.
2. We don't support right \<length> or bottom \<length> as these are
  implicit calc expressions (100% - \<length>).

We do support right \<percentage> and bottom \<percentage>.

Design doc:
https://docs.google.com/document/d/1FxkZdbyMRzmuVO8wk3qKoppPZdXeODmNMB9C11kSBgM/
