### PR TITLE
Implement contain for ray paths

### DIFF
--- a/examples/contain.html
+++ b/examples/contain.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../third_party/web-animations-js/web-animations.dev.js"></script>
+  <script src="../motion-path-polyfill.min.js"></script>
+  <style>
+    body {
+      margin: 0px;
+    }
+
+    #container {
+      width: 800px;
+      height: 800px;
+      background-color: rgb(255, 223, 255);
+      transform-style: preserve-3d;
+    }
+
+    #target {
+      position: absolute;
+      left: 300px;
+      top: 150px;
+      width: 90px;
+      height: 90px;
+      background-color: green;
+      transform-origin: 0px 0px;
+    }
+  </style>
+<script>
+  'use strict';
+  var keyframe = {
+    offsetPosition: '300px 150px',
+    offsetPath: 'ray(0deg closest-side contain)',
+    offsetDistance: '3000px',
+    offsetRotate: '0deg',
+    offsetAnchor: '0px 0px'
+  };
+  var keyframes = [keyframe, keyframe];
+  var timing = {duration: 0, fill: 'forwards'};
+  window.onload = function() {
+    target.animate(keyframes, timing);
+  };
+</script>
+</head>
+<body>
+  <div id="container">
+    <div id="target">
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/increase-size.html
+++ b/examples/increase-size.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../third_party/web-animations-js/web-animations.dev.js"></script>
+  <script src="../motion-path-polyfill.min.js"></script>
+  <style>
+    #container {
+      position: absolute;
+      left: 500px;
+      top: 100px;
+      background-color: rgb(255, 223, 255);
+      transform-style: preserve-3d;
+      width: 250px;
+      height: 250px;
+    }
+    .box {
+      width: 60%;
+      height: 10%;
+    }
+    #redBox {
+      background-color: red;
+    }
+    #blueBox {
+      background-color: blue;
+    }
+  </style>
+<script>
+  'use strict';
+  var keyframeRed = {
+    offsetPosition: '20% 20%',
+    offsetDistance: '0%',
+    offsetAnchor: '200% -300%',
+    offsetRotate: '0deg',
+    offsetPath: 'ray(-90deg closest-side)'
+  };
+  var keyframeBlue = {
+    offsetPosition: '20% 20%',
+    offsetDistance: '0%',
+    offsetAnchor: '200% -300%',
+    offsetRotate: '0deg',
+    offsetPath: 'ray(-90deg closest-side contain)'
+  };
+  var timing = {duration: 0, fill: 'forwards'};
+  window.onload = function() {
+    redBox.animate([keyframeRed, keyframeRed], timing);
+    blueBox.animate([keyframeBlue, keyframeBlue], timing);
+  };
+</script>
+</head>
+<body>
+  <div id="container">
+    <div class="box" id="redBox"></div>
+    <div class="box" id="blueBox"></div>
+  </div>
+</body>
+</html>

--- a/test/toTransformContain.js
+++ b/test/toTransformContain.js
@@ -1,0 +1,193 @@
+/* global suite test internalScope */
+'use strict';
+
+(function () {
+  var assertTransform = internalScope.assertTransform;
+
+  suite('toTransformContain', function () {
+    test('vertical', function () {
+      var containerStyle = {
+        position: 'absolute',
+        left: '0px',
+        top: '0px',
+        width: '200px',
+        height: '139px'
+      };
+
+      var targetStyle = {
+        width: '19px',
+        height: '5px',
+        position: 'absolute',
+        left: '85px',
+        top: '23px',
+        offsetPosition: '100px 25px',
+        offsetPath: 'ray(0deg closest-side contain)',
+        offsetDistance: '0%',
+        offsetRotate: '0deg',
+        offsetAnchor: 'auto', // use transformOrigin
+        transformOrigin: '15px 2px'
+      };
+
+      // In this test, left/top and offsetPosition/offsetAnchor imply the same location.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 0px, 0px)');
+
+      // A 15, 20, 25 triangle is formed by
+      // anchorX, |translation|+anchorY, path length
+      targetStyle.offsetDistance = '987%';
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, -18px, 0px)');
+
+      targetStyle.offsetPath = 'ray(180deg closest-side contain)';
+      targetStyle.offsetDistance = '-987%';
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, -18px, 0px)');
+
+      targetStyle.top = '98px';
+      targetStyle.offsetPosition = '100px 100px';
+      targetStyle.offsetDistance = '0%';
+
+      // left/top and offsetPosition/offsetAnchor imply the same location.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 0px, 0px)');
+
+      // A 15, 36, 39 triangle is formed by
+      // anchorX, translation+(height-anchorY), path length
+      targetStyle.offsetDistance = '987%';
+      targetStyle.offsetRotate = 'auto -90deg'; // Same as 0deg when ray bearing is 180deg.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 33px, 0px)');
+
+      targetStyle.offsetPath = 'ray(0deg closest-side contain)';
+      targetStyle.offsetDistance = '-987%';
+      targetStyle.offsetRotate = 'auto 90deg'; // Same as 0deg when ray bearing is 0deg.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 33px, 0px)');
+    });
+
+    test('horizontal', function () {
+      var containerStyle = {
+        position: 'absolute',
+        left: '0px',
+        top: '0px',
+        width: '139px',
+        height: '200px'
+      };
+
+      var targetStyle = {
+        width: '5px',
+        height: '19px',
+        position: 'absolute',
+        left: '23px',
+        top: '85px',
+        offsetPosition: '25px 100px',
+        offsetPath: 'ray(-90deg closest-side contain)',
+        offsetDistance: '0%',
+        offsetRotate: '0deg',
+        offsetAnchor: 'auto', // use transformOrigin
+        transformOrigin: '2px 15px'
+      };
+
+      // In this test, left/top and offsetPosition/offsetAnchor imply the same location.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 0px, 0px)');
+
+      // A 15, 20, 25 triangle is formed by
+      // anchorY, |translation|+anchorX, path length
+      targetStyle.offsetDistance = '987%';
+      assertTransform(containerStyle, targetStyle, 'translate3d(-18px, 0px, 0px)');
+
+      targetStyle.offsetPath = 'ray(90deg closest-side contain)';
+      targetStyle.offsetDistance = '-987%';
+      assertTransform(containerStyle, targetStyle, 'translate3d(-18px, 0px, 0px)');
+
+      targetStyle.left = '98px';
+      targetStyle.offsetPosition = '100px 100px';
+      targetStyle.offsetDistance = '0%';
+
+      // left/top and offsetPosition/offsetAnchor imply the same location.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 0px, 0px)');
+
+      // A 15, 36, 39 triangle is formed by
+      // anchorY, translation+(width-anchorX), path length
+      targetStyle.offsetDistance = '987%';
+      targetStyle.offsetRotate = 'auto'; // Same as 0deg when ray bearing is 90deg.
+      assertTransform(containerStyle, targetStyle, 'translate3d(33px, 0px, 0px)');
+
+      targetStyle.offsetPath = 'ray(-90deg closest-side contain)';
+      targetStyle.offsetDistance = '-987%';
+      targetStyle.offsetRotate = 'auto 180deg'; // Same as 0deg when ray bearing is -90deg.
+      assertTransform(containerStyle, targetStyle, 'translate3d(33px, 0px, 0px)');
+    });
+
+    test('diagonal', function () {
+      var containerStyle = {
+        position: 'absolute',
+        left: '0px',
+        top: '0px',
+        width: '200px',
+        height: '50px'
+      };
+
+      var targetStyle = {
+        width: '20px',
+        height: '50px',
+        position: 'absolute',
+        left: '80px',
+        top: '5px',
+        offsetPosition: '100px 25px',
+        offsetPath: 'ray(60deg sides contain)',
+        offsetDistance: '0%',
+        offsetRotate: 'auto',
+        offsetAnchor: 'auto', // use transformOrigin
+        transformOrigin: '20px 20px'
+      };
+
+      // In this test, left/top and offsetPosition/offsetAnchor imply the same location.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 0px, 0px) rotate(-30deg)');
+
+      // A 30, 40, 50 triangle is formed by
+      // height-anchorY, translation distance, path length
+      targetStyle.offsetDistance = '987%';
+      assertTransform(containerStyle, targetStyle, 'translate3d(34.64px, -20px, 0px) rotate(-30deg)');
+
+      // A 30, 40, 50 triangle is formed by
+      // height-anchorY, translation distance + width, path length
+      targetStyle.offsetPath = 'ray(240deg sides contain)';
+      targetStyle.offsetRotate = '-30deg';
+      assertTransform(containerStyle, targetStyle, 'translate3d(-17.32px, 10px, 0px) rotate(-30deg)');
+    });
+
+    test('expand', function () {
+      var containerStyle = {
+        position: 'absolute',
+        left: '300px',
+        top: '300px',
+        width: '0px',
+        height: '0px'
+      };
+
+      var targetStyle = {
+        width: '64px',
+        height: '102px',
+        position: 'absolute',
+        left: '-10px',
+        top: '-42px',
+        offsetPosition: '0px 0px',
+        offsetPath: 'ray(90deg closest-side)',
+        offsetDistance: '0%',
+        offsetRotate: '0deg',
+        offsetAnchor: 'auto', // use transformOrigin
+        transformOrigin: '10px 42px'
+      };
+
+      // In this test, left/top and offsetPosition/offsetAnchor imply the same location.
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, 0px, 0px)');
+
+      targetStyle.offsetPath = 'ray(360deg closest-side contain)';
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, -9px, 0px)');
+
+      targetStyle.offsetPath = 'ray(270deg closest-side contain)';
+      assertTransform(containerStyle, targetStyle, 'translate3d(-22px, 0px, 0px)');
+
+      targetStyle.offsetPath = 'ray(180deg closest-side contain)';
+      assertTransform(containerStyle, targetStyle, 'translate3d(0px, -9px, 0px)');
+
+      targetStyle.offsetPath = 'ray(90deg closest-side contain)';
+      assertTransform(containerStyle, targetStyle, 'translate3d(-22px, 0px, 0px)');
+    });
+  });
+})();


### PR DESCRIPTION
When 'contain' is specified on a ray path, the distance along the
path is clamped so that the element lies entirely within the path.

When no offset-distance would place the element entirely within the
path, the path length is minimally increased such that an
offset-distance exists that places the element within the path.

Spec:
https://drafts.fxtf.org/motion-1/#valdef-offsetpath-ray
