### PR TITLE
Avoid division by zero

### DIFF
--- a/src/toTransform.js
+++ b/src/toTransform.js
@@ -76,7 +76,9 @@
     var offsetDistanceLength = getOffsetDistanceLength(offsetDistance, pathLength);
 
     if (closedLoop) {
-      if (offsetDistanceLength < 0) {
+      if (pathLength === 0) {
+        offsetDistanceLength = 0;
+      } else if (offsetDistanceLength < 0) {
         offsetDistanceLength = offsetDistanceLength % pathLength + pathLength;
       } else {
         offsetDistanceLength = offsetDistanceLength % pathLength;

--- a/test/pathBasicShapeCircleTest.js
+++ b/test/pathBasicShapeCircleTest.js
@@ -60,6 +60,16 @@
                                     {at: 1, is: 'translate3d(100px, 90px, 0px)'}
          ]
         );
+
+       // TODO: Support path interpolation for basic shapes.
+       assertTransformInterpolation([
+                                    {'offsetPath': 'circle(0px at 100px 200px)', 'offsetDistance': '1000px', 'offsetRotate': '0deg', 'offsetAnchor': '50% 50%'},
+                                    {'offsetPath': 'circle(0px at 300px 400px)', 'offsetDistance': '1000px', 'offsetRotate': '0deg', 'offsetAnchor': '50% 50%'}],
+         [
+                                    {at: 0, is: 'translate3d(100px, 200px, 0px)'},
+                                    {at: 1, is: 'translate3d(300px, 400px, 0px)'}
+         ]
+        );
      });
    });
  })();


### PR DESCRIPTION
When the path length is 0, the distance along the closed path is always
0.

Added comment that interpolation for basic shapes is not yet
implemented.